### PR TITLE
Rebuild (for blktap's trigger scriptlet)

### DIFF
--- a/SPECS/mdadm.spec
+++ b/SPECS/mdadm.spec
@@ -4,7 +4,7 @@
 %global xsrel %{xsver}%{?xscount}%{?xshash}
 Name:        mdadm
 Version:     4.2
-Release:     %{?xsrel}%{?dist}
+Release:     %{?xsrel}.1%{?dist}
 Summary:     The mdadm program controls Linux md devices (software RAID arrays)
 URL:         http://www.kernel.org/pub/linux/utils/raid/mdadm/
 License:     GPLv2+
@@ -205,6 +205,9 @@ install -d -m 0710 %{buildroot}/run/%{name}/
 /usr/share/mdadm/mdcheck
 
 %changelog
+* Tue Apr 07 2026 Philippe Coval <philippe.coval@vates.tech> - 4.2-5.1
+- Rebuild (for blktap's trigger scriptlet)
+
 * Thu Jun 19 2025 Gerald Elder-Vass <gerald.elder-vass@cloud.com> - 4.2-5
 - Disable rpmlint hardcoded path checks
 


### PR DESCRIPTION
Rebuild (for blktap's trigger scriptlet)

blktap triggers a scriptlet on mdadm update.
There was an issue on the scriptlet.

    sudo yum reinstall mdadm
    Installing : mdadm-4.2-5.xcpng8.3.x86_64 1/1
    cat: /usr/lib/udev/rules.d/65-md-incremental.rules: No such file or directory
    warning: %triggerin(blktap-3.55.5-6.3.xcpng8.3.x86_64) scriptlet failed, exit status 1
    Non-fatal <unknown> scriptlet failure in rpm package mdadm-4.2-5.xcpng8.3.x86_64

The cause is a mdadm's udev rule that was relocated and scriptlet
fixed accordingly in related change.

This mdadm version is bumped to run fixed triggerin from blktap.

Note the relationship can't be declared with RPM 4.11.3 because
Recommends and/or Suggests were introduced in later version:

Reference: https://rpm.org/docs/4.19.x/manual/dependencies.html

Relate-to: XCPNG-3024
Relate-to: https://github.com/xcp-ng-rpms/blktap/pull/17
